### PR TITLE
target="_blank"用アイコンを表示

### DIFF
--- a/resources/views/scenario/manage_detail.blade.php
+++ b/resources/views/scenario/manage_detail.blade.php
@@ -68,7 +68,7 @@
                     <h5>セッション参加者</h5>
                     <span>
                         @foreach ($detail->characters as $character)
-                        <a href="https://{{ CharacterConsts::SERVICE_DOMAIN_LIST[$character->service] }}{{ $character->character_sheet }}" target="_blank" rel="noopener noreferrer">{{ $character->name }}</a>
+                        <a href="https://{{ CharacterConsts::SERVICE_DOMAIN_LIST[$character->service] }}{{ $character->character_sheet }}" target="_blank" rel="noopener noreferrer">{{ $character->name }}@include('layouts.blank')</a>
                         （{{ $character->user->user_name }}）@if (!$loop->last),&ensp;@endif
                         @endforeach
                     </span>


### PR DESCRIPTION
管理画面のセッション参加者のキャラクターシート閲覧リンクで、target="_blank"用のアイコンを表示していないバグを修正。